### PR TITLE
Rename var.tf to variables.tf, move defaults

### DIFF
--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -1,0 +1,6 @@
+domain    = "billy-euceda.com"
+subdomain = "www.billy-euceda.com"
+table     = "visit-count-table"
+function  = "visit-count-function"
+api       = "visit-count-api"
+

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,32 +1,25 @@
 variable "domain" {
   description = "domain name and domain bucket name"
-  type = string
-  default = "billy-euceda.com"
+  type        = string
 }
 
 variable "subdomain" {
   description = "subdomain name and subdomain bucket name"
-  type = string
-  default = "www.billy-euceda.com"
+  type        = string
 }
 
 variable "table" {
   description = "visit count dynamodb table"
-  type = string
-  default = "visit-count-table"
+  type        = string
 }
 
 variable "function" {
   description = "AWS visit count lambda function"
-  type = string
-  default = "visit-count-function"
+  type        = string
 }
 
 variable "api" {
   description = "visit count api name"
-  type = string
-  default = "visit-count-api"
+  type        = string
 }
-
-
 


### PR DESCRIPTION
fixes #5 

- Renamed `var.tf` to the more standard name `variables.tf`
- Move default variables out of `variables.tf` and into a `terraform.tfvars` file.
- Ran `terraform fmt` on `variables.tf` and `terraform.tfvars`